### PR TITLE
Fix: Maintain alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Command design pattern. You can also use the `FailoverOnMissContainer` decorator
 
 * [Aura.Di Container](https://github.com/auraphp/Aura.Di/blob/develop/src/Aura/Di/ContainerInterface.php)
 * [Guzzle Service Builder](https://github.com/guzzle/service/blob/master/Builder/ServiceBuilderInterface.php)
-* [League Container](https://github.com/thephpleague/container/blob/master/src/ContainerInterface.php)
 * [Laravel Container](https://github.com/laravel/framework/blob/master/src/Illuminate/Container/Container.php)
+* [League Container](https://github.com/thephpleague/container/blob/master/src/ContainerInterface.php)
 * [Nette DI Container](https://github.com/nette/nette/blob/master/Nette/DI/Container.php)
 * [Pimple](https://github.com/fabpot/Pimple/blob/master/lib/Pimple.php)
 * [PHP-DI Container](https://github.com/mnapoli/PHP-DI/blob/master/src/DI/Container.php)

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         "aura/di": "1.*",
         "guzzle/service": "3.*",
         "illuminate/container": "4.*",
+        "league/container": "1.*",
         "mnapoli/php-di": "3.*",
         "nette/nette": "2.*",
         "phpunit/phpunit": "3.7.*",
         "pimple/pimple": "1.*",
         "symfony/dependency-injection": "2.*",
         "zendframework/zend-di": "2.*",
-        "zendframework/zend-servicemanager": "2.*",
-        "league/container": "1.*"
+        "zendframework/zend-servicemanager": "2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR
- [x] attempts to keep both the list of dependencies, as well as the list of container adapters in order

Related to https://github.com/jeremeamia/acclimate-container/pull/16.
