### PR TITLE
Fix: Move return statement

### DIFF
--- a/src/Adapter/LeagueContainerAdapter.php
+++ b/src/Adapter/LeagueContainerAdapter.php
@@ -41,10 +41,10 @@ class LeagueContainerAdapter implements AcclimateContainerInterface
     {
         try {
             $this->container->get($id);
-
-            return true;
         } catch (ReflectionException $e) {
             return false;
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
This PR
- [x] moves a `return` statement

Related to https://github.com/jeremeamia/acclimate-container/pull/16.
